### PR TITLE
Changed Properties typealias to use Any instead of AnyObject

### DIFF
--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -80,7 +80,7 @@ extension Adobe: LocationTracking {
      - returns: A tracking result.
      */
     public func track(location: CLLocation,
-                              withAdditionalProperties properties: [String: AnyObject]?) -> TrackingResult {
+                              withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackLocation(location, data: properties)
         return .success
     }

--- a/Simcoe/Properties.swift
+++ b/Simcoe/Properties.swift
@@ -7,4 +7,4 @@
 //
 
 /// The properties.
-public typealias Properties = [String: AnyObject]
+public typealias Properties = [String: Any]


### PR DESCRIPTION
Most of the properties we use Simcoe for are strings, and String does not conform to AnyObject protocol, so we need it changes to Any instead.