### PR TITLE
[Bugfix] Update Dict Types | Documentation | Protocol Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,19 +110,6 @@ While simply implementing this protocol is all you need for your object to be a 
 
 So for your analytics provider to be able to handle page views in the Simcoe framework, your provider should implement the `PageViewTracking` protocol. This plug-and-play API allows you to define what you want your provider to handle at a very granular level. If your provider only needs to implement location tracking and nothing else, then you need only implement the `LocationTracking` protocol (as well as the `AnalyticsTracking` protocol, of course); all other protocols are optional. This allows you full customization as to how your objects respond to Simcoe.
 
-Each provider type defined above maps directly to a Simcoe function that will call that method. These are, respectively:
-
-* `logAddToCart`, `logRemoveFromCart`
-* `trackCheckoutEvent`
-* `logError`
-* `trackEvent`
-* `increaseLifetimeValue`
-* `trackLocation`
-* `trackPageView`
-* `trackPurchaseEvent`
-* `setUserAttribute`
-* `logViewDetail`
-
 #### Additional Tracking
 
 Each analytics implementation is different, and Simcoe doesn't expect to be the be-all, end-all of analytics implementations. What if you need to track something that is not included in the base SDK?

--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -57,7 +57,7 @@ extension Adobe: LifetimeValueIncreasing {
     public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
         var data = properties ?? Properties()
         if let item = item {
-            data[item] = "" as String
+            data[item] = ""
         }
 
         ADBMobile.trackLifetimeValueIncrease(1, data: data)

--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -56,12 +56,12 @@ extension Adobe: LifetimeValueIncreasing {
      - returns: A tracking result.
      */
     public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
-        var data = properties ?? [String: AnyObject]()
+        var data = properties ?? Properties()
         if let item = item {
-            data[item] = "" as AnyObject
+            data[item] = "" as UInt
         }
 
-        ADBMobile.trackLifetimeValueIncrease(NSDecimalNumber(value: 1), data: data)
+        ADBMobile.trackLifetimeValueIncrease(Decimal(1), data: data)
         return .success
     }
 

--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -10,7 +10,7 @@ import AdobeMobileSDK
 import CoreLocation
 
 /// The adobe analytics provider.
-open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, PageViewTracking {
+public class Adobe {
 
     /// The name of the tracker.
     open let name = "Adobe Omniture"
@@ -23,7 +23,11 @@ open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, Page
         ADBMobile.collectLifecycleData()
     }
 
-    // MARK: - EventTracking
+}
+
+// MARK: - EventTracking
+
+extension Adobe: EventTracking {
 
     /// Tracks the given event with optional additional properties.
     ///
@@ -31,13 +35,17 @@ open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, Page
     ///   - event: The event to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    open func track(event: String,
-                      withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(event: String,
+                    withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackAction(event, data: properties)
         return .success
     }
 
-    // MARK: - LifetimeValueIncreasing
+}
+
+// MARK: - LifetimeValueIncreasing
+
+extension Adobe: LifetimeValueIncreasing {
 
     /// Increases the lifetime value of the key by the specified amount.
     ///
@@ -46,7 +54,7 @@ open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, Page
     ///   - item: The optional item to extend.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    open func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
         var data = properties ?? Properties()
         if let item = item {
             data[item] = "" as String
@@ -56,7 +64,11 @@ open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, Page
         return .success
     }
 
-    // MARK: - LocationTracking
+}
+
+// MARK: - LocationTracking
+
+extension Adobe: LocationTracking {
 
     /// Tracks location.
     ///
@@ -64,13 +76,17 @@ open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, Page
     ///   - location: The location to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    open func track(location: CLLocation,
-                      withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(location: CLLocation,
+                    withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackLocation(location, data: properties)
         return .success
     }
 
-    // MARK: - PageViewTracking
+}
+
+// MARK: - PageViewTracking
+
+extension Adobe: PageViewTracking {
 
     /// Tracks the page view.
     ///
@@ -78,7 +94,7 @@ open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, Page
     ///   - pageView: The page view to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    open func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackState(pageView, data: properties)
         return .success
     }

--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -60,7 +60,7 @@ extension Adobe: LifetimeValueIncreasing {
             data[item] = ""
         }
 
-        ADBMobile.trackLifetimeValueIncrease(1, data: data)
+        ADBMobile.trackLifetimeValueIncrease(NSDecimalNumber(value: amount), data: data)
         return .success
     }
 

--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -10,7 +10,7 @@ import AdobeMobileSDK
 import CoreLocation
 
 /// The adobe analytics provider.
-open class Adobe {
+open class Adobe: EventTracking, LifetimeValueIncreasing, LocationTracking, PageViewTracking {
 
     /// The name of the tracker.
     open let name = "Adobe Omniture"
@@ -23,11 +23,7 @@ open class Adobe {
         ADBMobile.collectLifecycleData()
     }
 
-}
-
-// MARK: - EventTracking
-
-extension Adobe: EventTracking {
+    // MARK: - EventTracking
 
     /// Tracks the given event with optional additional properties.
     ///
@@ -35,17 +31,13 @@ extension Adobe: EventTracking {
     ///   - event: The event to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func track(event: String,
+    open func track(event: String,
                       withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackAction(event, data: properties)
         return .success
     }
 
-}
-
-// MARK: - LifetimeValueIncreasing
-
-extension Adobe: LifetimeValueIncreasing {
+    // MARK: - LifetimeValueIncreasing
 
     /// Increases the lifetime value of the key by the specified amount.
     ///
@@ -54,21 +46,17 @@ extension Adobe: LifetimeValueIncreasing {
     ///   - item: The optional item to extend.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
-            var data = properties ?? Properties()
-            if let item = item {
-                data[item] = "" as String
-            }
+    open func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
+        var data = properties ?? Properties()
+        if let item = item {
+            data[item] = "" as String
+        }
 
-            ADBMobile.trackLifetimeValueIncrease(1, data: data)
-            return .success
+        ADBMobile.trackLifetimeValueIncrease(1, data: data)
+        return .success
     }
 
-}
-
-// MARK: - LocationTracking
-
-extension Adobe: LocationTracking {
+    // MARK: - LocationTracking
 
     /// Tracks location.
     ///
@@ -76,17 +64,13 @@ extension Adobe: LocationTracking {
     ///   - location: The location to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func track(location: CLLocation,
+    open func track(location: CLLocation,
                       withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackLocation(location, data: properties)
         return .success
     }
 
-}
-
-// MARK: - PageViewTracking
-
-extension Adobe: PageViewTracking {
+    // MARK: - PageViewTracking
 
     /// Tracks the page view.
     ///
@@ -94,9 +78,9 @@ extension Adobe: PageViewTracking {
     ///   - pageView: The page view to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    open func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackState(pageView, data: properties)
         return .success
     }
-    
+
 }

--- a/Simcoe/Adobe/Adobe.swift
+++ b/Simcoe/Adobe/Adobe.swift
@@ -35,34 +35,33 @@ extension Adobe: EventTracking {
     ///   - event: The event to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(event: String,
+                      withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackAction(event, data: properties)
         return .success
     }
-    
+
 }
 
 // MARK: - LifetimeValueIncreasing
 
 extension Adobe: LifetimeValueIncreasing {
 
-    /**
-     Increases the lifetime value of the key by the specified amount.
-
-     - parameter amount:     The amount to increase that lifetime value for.
-     - parameter item:       The optional item to extend.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Increases the lifetime value of the key by the specified amount.
+    ///
+    /// - Parameters:
+    ///   - amount: The amount to increase that lifetime value for.
+    ///   - item: The optional item to extend.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
-        var data = properties ?? Properties()
-        if let item = item {
-            data[item] = "" as UInt
-        }
+            var data = properties ?? Properties()
+            if let item = item {
+                data[item] = "" as String
+            }
 
-        ADBMobile.trackLifetimeValueIncrease(Decimal(1), data: data)
-        return .success
+            ADBMobile.trackLifetimeValueIncrease(1, data: data)
+            return .success
     }
 
 }
@@ -71,36 +70,33 @@ extension Adobe: LifetimeValueIncreasing {
 
 extension Adobe: LocationTracking {
 
-    /**
-     Tracks location.
-
-     - parameter location:   The location to track.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Tracks location.
+    ///
+    /// - Parameters:
+    ///   - location: The location to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     public func track(location: CLLocation,
-                              withAdditionalProperties properties: Properties?) -> TrackingResult {
+                      withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackLocation(location, data: properties)
         return .success
     }
-    
+
 }
 
 // MARK: - PageViewTracking
 
 extension Adobe: PageViewTracking {
 
-    /**
-     Tracks the page view.
-
-     - parameter pageView: The page view to track.
-
-     - returns: A tracking result.
-     */
+    /// Tracks the page view.
+    ///
+    /// - Parameters:
+    ///   - pageView: The page view to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     public func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         ADBMobile.trackState(pageView, data: properties)
         return .success
     }
-
+    
 }

--- a/Simcoe/Analytics Tracking Protocols/AnalyticsTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/AnalyticsTracking.swift
@@ -6,10 +6,8 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Default protocol for an object being trackable for analytics. All analytics items that wish to
- be tracked must, at least, implement this protocol.
- */
+/// Default protocol for an object being trackable for analytics. All analytics items that wish to
+/// be tracked must, at least, implement this protocol.
 public protocol AnalyticsTracking {
 
     /// The name of the tracker. This is used for debugging purposes only, but should
@@ -18,26 +16,23 @@ public protocol AnalyticsTracking {
     /// return "Adobe Omniture".
     var name: String { get }
 
-    /**
-     Starts tracking analytics. This is called on all providers passed to `Simcoe.run`.
-     Your analytics tracker should start tracking lifecycle data or setup anything else
-     that needs to run for the duration of the analytics lifecycle.
 
-     This is an optional value and is implemented by default in an extension to do nothing.
-     */
+    /// Starts tracking analytics. This is called on all providers passed to `Simcoe.run`.
+    /// Your analytics tracker should start tracking lifecycle data or setup anything else
+    /// that needs to run for the duration of the analytics lifecycle.
+    ///
+    /// This is an optional value and is implemented by default in an extension to do nothing.
     func start()
 
 }
 
 public extension AnalyticsTracking {
 
-    /**
-     Starts tracking analytics. This is called on all providers passed to `Simcoe.run`.
-     Your analytics tracker should start tracking lifecycle data or setup anything else
-     that needs to run for the duration of the analytics lifecycle.
-
-     This is an optional value and is implemented by default in an extension to do nothing.
-     */
+    /// Starts tracking analytics. This is called on all providers passed to `Simcoe.run`.
+    /// Your analytics tracker should start tracking lifecycle data or setup anything else
+    /// that needs to run for the duration of the analytics lifecycle.
+    ///
+    /// This is an optional value and is implemented by default in an extension to do nothing.
     func start() {
 
     }

--- a/Simcoe/Analytics Tracking Protocols/CartLogging.swift
+++ b/Simcoe/Analytics Tracking Protocols/CartLogging.swift
@@ -6,25 +6,23 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- *  Defines functionality for logging cart actions.
- */
+/// Defines functionality for logging cart actions.
 public protocol CartLogging: AnalyticsTracking {
 
     /// Logs the addition of a product to the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult
 
     /// Logs the removal of a product from the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult
     
 }

--- a/Simcoe/Analytics Tracking Protocols/CheckoutTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/CheckoutTracking.swift
@@ -6,17 +6,15 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- *  Defines functionality for tracking checkout actions.
- */
+/// Defines functionality for tracking checkout actions.
 public protocol CheckoutTracking: AnalyticsTracking {
 
     /// Tracks a checkout event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult
 
 }

--- a/Simcoe/Analytics Tracking Protocols/ErrorLogging.swift
+++ b/Simcoe/Analytics Tracking Protocols/ErrorLogging.swift
@@ -6,19 +6,15 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Defines methods for logging errors to analytics.
- */
+/// Defines methods for logging errors to analytics.
 public protocol ErrorLogging: AnalyticsTracking {
-    
-    /**
-     Logs the error with optional additional properties.
-     
-     - parameter error:      The error to log.
-     - parameter properties: The optional additional properties.
-     
-     - returns: A tracking result.
-     */
+
+    /// Logs the error with optional additional properties.
+    ///
+    /// - Parameters:
+    ///   - error: The error to log.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func log(error: String, withAdditionalProperties properties: Properties?) -> TrackingResult
     
 }

--- a/Simcoe/Analytics Tracking Protocols/EventTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/EventTracking.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Defines methods for tracking analytics events.
- */
+/// Defines methods for tracking analytics events.
 public protocol EventTracking: AnalyticsTracking {
 
     /// Tracks the given event with optional additional properties.

--- a/Simcoe/Analytics Tracking Protocols/LifetimeValueIncreasing.swift
+++ b/Simcoe/Analytics Tracking Protocols/LifetimeValueIncreasing.swift
@@ -6,20 +6,16 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Defines methods for increasing a lifetime value of an analytics key.
- */
+/// Defines methods for increasing a lifetime value of an analytics key.
 public protocol LifetimeValueIncreasing: AnalyticsTracking {
 
-    /**
-     Increases the lifetime value of the key by the specified amount.
-
-     - parameter amount:     The amount to increase that lifetime value for.
-     - parameter item:       The optional item to extend.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Increases the lifetime value of the key by the specified amount.
+    ///
+    /// - Parameters:
+    ///   - amount: The amount to increase that lifetime value for.
+    ///   - item: The optional item to extend.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func increaseLifetimeValue(byAmount amount: Double,
                                         forItem item: String?,
                                                 withAdditionalProperties properties: Properties?) -> TrackingResult

--- a/Simcoe/Analytics Tracking Protocols/LocationTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/LocationTracking.swift
@@ -8,19 +8,15 @@
 
 import CoreLocation
 
-/**
- Defines methods for tracking a user's location data.
- */
+/// Defines methods for tracking a user's location data.
 public protocol LocationTracking: AnalyticsTracking {
 
-    /**
-     Tracks location.
-
-     - parameter location:   The location to track.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Tracks location.
+    ///
+    /// - Parameters:
+    ///   - location: The location to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult
 
 }

--- a/Simcoe/Analytics Tracking Protocols/PageViewTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/PageViewTracking.swift
@@ -6,18 +6,15 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Defines functionality for tracking page views.
- */
+/// Defines functionality for tracking page views.
 public protocol PageViewTracking: AnalyticsTracking {
 
-    /**
-     Tracks the page view.
-
-     - parameter pageView: The page view to track.
-
-     - returns: A tracking result.
-     */
+    /// Tracks the page view.
+    ///
+    /// - Parameters:
+    ///   - pageView: The page view to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult
 
 }

--- a/Simcoe/Analytics Tracking Protocols/PurchaseTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/PurchaseTracking.swift
@@ -6,17 +6,15 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- *  Defines functionality for tracking purchase actions.
- */
+/// Defines functionality for tracking purchase actions.
 public protocol PurchaseTracking: AnalyticsTracking {
 
     /// Tracks a purchase event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties
+    /// - Returns: A tracking result.
     func trackPurchaseEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult
 
 }

--- a/Simcoe/Analytics Tracking Protocols/UserAttributeTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/UserAttributeTracking.swift
@@ -6,19 +6,15 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Defines functionality for logging errors to analytics.
- */
+/// Defines functionality for logging errors to analytics.
 public protocol UserAttributeTracking: AnalyticsTracking {
-    
-    /**
-     Sets the User Attribute.
-     
-     - parameter key:      The attribute key to log.
-     - parameter value:    The attribute value to log.
-     
-     - returns: A tracking result.
-     */
+
+    /// Sets the User Attribute.
+    ///
+    /// - Parameters:
+    ///   - key: The attribute key to log.
+    ///   - value: The attribute value to log.
+    /// - Returns: A tracking result.
     func setUserAttribute(_ key: String, value: Any) -> TrackingResult
     
 }

--- a/Simcoe/Analytics Tracking Protocols/UserAttributeTracking.swift
+++ b/Simcoe/Analytics Tracking Protocols/UserAttributeTracking.swift
@@ -19,6 +19,6 @@ public protocol UserAttributeTracking: AnalyticsTracking {
      
      - returns: A tracking result.
      */
-    func setUserAttribute(_ key: String, value: AnyObject) -> TrackingResult
+    func setUserAttribute(_ key: String, value: Any) -> TrackingResult
     
 }

--- a/Simcoe/Analytics Tracking Protocols/ViewDetailLogging.swift
+++ b/Simcoe/Analytics Tracking Protocols/ViewDetailLogging.swift
@@ -6,17 +6,15 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- *  Defines functionality for logging view detail actions.
- */
+/// Defines functionality for logging view detail actions.
 public protocol ViewDetailLogging: AnalyticsTracking {
 
     /// Logs the action of viewing a product's details.
     ///
-    /// - parameter product: The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult
 
 }

--- a/Simcoe/ConsoleOutput.swift
+++ b/Simcoe/ConsoleOutput.swift
@@ -9,11 +9,9 @@
 /// The default console output.
 internal final class ConsoleOutput: Output {
 
-    /**
-     Prints a message to the standard output.
-
-     - parameter message: The message to print.
-     */
+    /// Prints a message to the standard output.
+    ///
+    /// - Parameter message: The message to print.
     func print(_ message: String) {
         Swift.print(message)
     }

--- a/Simcoe/EmptyProvider.swift
+++ b/Simcoe/EmptyProvider.swift
@@ -22,20 +22,20 @@ extension EmptyProvider: CartLogging {
 
     /// Logs the addition of a product to the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         return .success
     }
 
     /// Logs the removal of a product from the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         return .success
     }
@@ -47,10 +47,10 @@ extension EmptyProvider: CheckoutTracking {
 
     /// Tracks a checkout event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         return .success
     }
@@ -61,14 +61,12 @@ extension EmptyProvider: CheckoutTracking {
 
 extension EmptyProvider: ErrorLogging {
 
-    /**
-     Logs the error with optional additional properties.
-
-     - parameter error:      The error to log.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Logs the error with optional additional properties.
+    ///
+    /// - Parameters:
+    ///   - error: The error to log.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func log(error: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         return .success
     }
@@ -79,14 +77,12 @@ extension EmptyProvider: ErrorLogging {
 
 extension EmptyProvider: EventTracking {
 
-    /**
-     Tracks the given event with optional additional properties.
-
-     - parameter event:      The event to tack.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Tracks the given event with optional additional properties.
+    ///
+    /// - Parameters:
+    ///   - event: The event to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         return .success
     }
@@ -97,15 +93,13 @@ extension EmptyProvider: EventTracking {
 
 extension EmptyProvider: LifetimeValueIncreasing {
 
-    /**
-     Increases the lifetime value of the key by the specified amount.
-
-     - parameter amount:     The amount to increase that lifetime value for.
-     - parameter item:       The optional item to extend.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Increases the lifetime value of the key by the specified amount.
+    ///
+    /// - Parameters:
+    ///   - amount: The amount to increase that lifetime value for.
+    ///   - item: The optional item to extend.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func increaseLifetimeValue(byAmount amount: Double, forItem item: String?, withAdditionalProperties properties: Properties?) -> TrackingResult {
         return .success
     }
@@ -116,14 +110,12 @@ extension EmptyProvider: LifetimeValueIncreasing {
 
 extension EmptyProvider: LocationTracking {
 
-    /**
-     Tracks location.
-
-     - parameter location:   The location to track.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Tracks location.
+    ///
+    /// - Parameters:
+    ///   - location: The location to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
         return .success
     }
@@ -134,13 +126,12 @@ extension EmptyProvider: LocationTracking {
 
 extension EmptyProvider: PageViewTracking {
 
-    /**
-     Tracks the page view.
-
-     - parameter pageView: The page view to track.
-
-     - returns: A tracking result.
-     */
+    /// Tracks the page view.
+    ///
+    /// - Parameters:
+    ///   - pageView: The page view to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         return .success
     }
@@ -153,10 +144,10 @@ extension EmptyProvider: PurchaseTracking {
 
     /// Tracks a purchase event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties
+    /// - Returns: A tracking result.
     func trackPurchaseEvent<T : SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         return .success
     }
@@ -167,14 +158,12 @@ extension EmptyProvider: PurchaseTracking {
 
 extension EmptyProvider: UserAttributeTracking {
 
-    /**
-     Sets the User Attribute.
-
-     - parameter key:      The attribute key to log.
-     - parameter value:    The attribute value to log.
-
-     - returns: A tracking result.
-     */
+    /// Sets the User Attribute.
+    ///
+    /// - Parameters:
+    ///   - key: The attribute key to log.
+    ///   - value: The attribute value to log.
+    /// - Returns: A tracking result.
     func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         return .success
     }
@@ -187,10 +176,10 @@ extension EmptyProvider: ViewDetailLogging {
 
     /// Logs the action of viewing a product's details.
     ///
-    /// - parameter product: The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     func logViewDetail<T : SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         return .success
     }

--- a/Simcoe/EmptyProvider.swift
+++ b/Simcoe/EmptyProvider.swift
@@ -175,7 +175,7 @@ extension EmptyProvider: UserAttributeTracking {
 
      - returns: A tracking result.
      */
-    func setUserAttribute(_ key: String, value: AnyObject) -> TrackingResult {
+    func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         return .success
     }
     

--- a/Simcoe/EnumerationListable.swift
+++ b/Simcoe/EnumerationListable.swift
@@ -17,9 +17,8 @@ extension EnumerationListable where Self: RawRepresentable {
 
     /// The unfound keys in the provided Properties.
     ///
-    /// - parameter properties: The properties.
-    ///
-    /// - returns: The unfound keys.
+    /// - Parameter properties: The properties.
+    /// - Returns: The unfound keys.
     fileprivate static func unfoundKeys(_ properties: Properties) -> [String] {
         let allKeyRawValues: [String] = Self.allKeys.flatMap { $0.rawValue as? String }
         let allKeyRawValuesSet = Set(allKeyRawValues)
@@ -32,9 +31,8 @@ extension EnumerationListable where Self: RawRepresentable {
 
     /// The remaining properties.
     ///
-    /// - parameter properties: The properties.
-    ///
-    /// - returns: The remaining properties.
+    /// - Parameter properties: The properties.
+    /// - Returns: The remaining properties.
     static func remaining(properties: Properties) -> Properties {
         let unfoundKeys = Self.unfoundKeys(properties)
         var additionalProperties = Properties()

--- a/Simcoe/ErrorHandlingOption.swift
+++ b/Simcoe/ErrorHandlingOption.swift
@@ -6,13 +6,11 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- The various options for handling errors.
-
- - Suppress: Suppresses errors; basically any error is ignored.
- - Default:  Default error handling; errors are logged to the output log.
- - Strict:   Strict error handling; any errors encountered will trigger a fatalError().
- */
+/// The various options for handling errors.
+///
+/// - suppress: Suppresses errors; basically any error is ignored.
+/// - `default`: Default error handling; errors are logged to the output log.
+/// - strict: Strict error handling; any errors encountered will trigger a fatalError().
 public enum ErrorHandlingOption {
 
     case suppress

--- a/Simcoe/Event.swift
+++ b/Simcoe/Event.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- A Simcoe Event.
- */
+/// A Simcoe Event.
 internal struct Event {
 
     /// The write actions that occurred in this event.

--- a/Simcoe/Output.swift
+++ b/Simcoe/Output.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- Defines an object as an output source.
- */
+/// Defines an object as an output source.
 internal protocol Output {
 
     /// Prints a message to the output source.

--- a/Simcoe/OutputOptions.swift
+++ b/Simcoe/OutputOptions.swift
@@ -6,15 +6,13 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- The various options for how to output records to the standard output.
-
- - None:    No output; disables records displaying in the output.
- - Simple:  Only outputs one item per event, no matter how many providers were recorded.
- - Verbose: Outputs one line for each provider per event, specifying which provider was recorded.
- This is the best option if you are using many providers and want to verify data is being output
- to each one.
- */
+/// The various options for how to output records to the standard output.
+///
+/// - none: No output; disables records displaying in the output.
+/// - simple: Only outputs one item per event, no matter how many providers were recorded.
+/// - verbose: Outputs one line for each provider per event, specifying which provider was recorded.
+///   This is the best option if you are using many providers and want to verify data is being output
+///   to each one.
 public enum OutputOptions {
 
     case none

--- a/Simcoe/RemoteOutput.swift
+++ b/Simcoe/RemoteOutput.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 
-/**
- *  A remote output source.
- */
+/// A remote output source.
 internal struct RemoteOutput: Output {
 
     /// The token.

--- a/Simcoe/Simcoe.swift
+++ b/Simcoe/Simcoe.swift
@@ -367,7 +367,7 @@ public final class Simcoe {
      - parameter key:   The key of the user attribute
      - parameter value: the value of the user attribute
      */
-    public static func setUserAttribute(_ key: String, value: AnyObject) {
+    public static func setUserAttribute(_ key: String, value: Any) {
         engine.setUserAttribute(key, value: value)
     }
 
@@ -377,7 +377,7 @@ public final class Simcoe {
      - parameter key:   The key of the user attribute
      - parameter value: the value of the user attribute
      */
-    func setUserAttribute(_ key: String, value: AnyObject) {
+    func setUserAttribute(_ key: String, value: Any) {
         let providers: [UserAttributeTracking] = findProviders()
         
         write(toProviders: providers, description: "Setting user attribute with key: \(key) value:\(value)") { attributeSetter in

--- a/Simcoe/Simcoe.swift
+++ b/Simcoe/Simcoe.swift
@@ -33,33 +33,24 @@ public final class Simcoe {
         }
     }
 
-    /**
-     Initializes a new instance using the specified tracker.
-
-     - parameter tracker: The tracker to use.
-
-     - returns: An instance of Simcoe.
-     */
+    /// Initializes a new instance using the specified tracker.
+    ///
+    /// - Parameter tracker: The tracker to use.
     init(tracker: Tracker) {
         self.tracker = tracker
     }
 
-    /**
-     Retrieves the provider based on its kind from the current list of providers.
-
-     - parameter _: The kind of provider to retrieve.
-
-     - returns: The provider if it is exists; otherwise nil.
-     */
+    /// Retrieves the provider based on its kind from the current list of providers.
+    ///
+    /// - Parameter _: The kind of provider to retrieve.
+    /// - Returns: The provider if it is exists; otherwise nil.
     public static func provider<T: AnalyticsTracking>(ofKind _: T) -> T? {
         return engine.providers.filter({ provider in return provider is T }).first as? T
     }
 
-    /**
-     Begins running using the input providers.
-
-     - parameter providers: The providers to use for analytics tracking.
-     */
+    /// Begins running using the input providers.
+    ///
+    /// - Parameter providers: The providers to use for analytics tracking.
     public static func run(with providers: [AnalyticsTracking] = [AnalyticsTracking]()) {
         var analyticsProviders = providers
         if analyticsProviders.isEmpty {
@@ -69,13 +60,12 @@ public final class Simcoe {
         engine.providers = analyticsProviders
     }
 
-    /**
-     Writes the event.
-
-     - parameter providers:   The list of provides.
-     - parameter description: The event description.
-     - parameter action:      The action description.
-     */
+    /// Writes the event.
+    ///
+    /// - Parameters:
+    ///   - providers: The list of providers.
+    ///   - description: The event description.
+    ///   - action: The action description.
     public func write<T>(toProviders providers: [T], description: String, action: (T) -> TrackingResult) {
         let writeEvents = providers.map { provider -> WriteEvent in
             let result = action(provider)
@@ -96,20 +86,18 @@ public final class Simcoe {
 
     /// Logs the addition of a product to the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
     public static func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) {
         engine.logAddToCart(product, eventProperties: eventProperties)
     }
 
     /// Logs the addition of a product to the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
     func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) {
         let providers: [CartLogging] = findProviders()
         let simcoeProduct = product.toSimcoeProduct()
@@ -127,20 +115,18 @@ public final class Simcoe {
 
     /// Logs the removal of a product from the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
     public static func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) {
         engine.logRemoveFromCart(product, eventProperties: eventProperties)
     }
 
     /// Logs the removal of a product from the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
     func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) {
         let providers: [CartLogging] = findProviders()
         let simcoeProduct = product.toSimcoeProduct()
@@ -160,20 +146,18 @@ public final class Simcoe {
 
     /// Tracks a checkout event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties.
     public static func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) {
         engine.trackCheckoutEvent(products, eventProperties: eventProperties)
     }
 
     /// Tracks a checkout event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties.
     func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) {
         let providers: [CheckoutTracking] = findProviders()
         let propertiesString = eventProperties != nil ? "=> \(eventProperties!.description)" : ""
@@ -191,22 +175,20 @@ public final class Simcoe {
 
     // MARK: - ErrorLogging
 
-    /**
-     Logs the error with optional additional properties.
-
-     - parameter error:      The error to log.
-     - parameter properties: The optional additional properties.
-     */
+    /// Logs the error with optional additional properties.
+    ///
+    /// - Parameters:
+    ///   - error: The error to log.
+    ///   - properties: The optional additional properties.
     public static func log(error: String, withAdditionalProperties properties: Properties? = nil) {
         engine.log(error: error, withAdditionalProperties: properties)
     }
 
-    /**
-     Logs the error with optional additional properties.
-
-     - parameter error:      The error to log.
-     - parameter properties: The optional additional properties.
-     */
+    /// Logs the error with optional additional properties.
+    ///
+    /// - Parameters:
+    ///   - error: The error to log.
+    ///   - properties: The optional additional properties.
     func log(error: String, withAdditionalProperties properties: Properties? = nil) {
         let providers: [ErrorLogging] = findProviders()
 
@@ -218,22 +200,20 @@ public final class Simcoe {
 
     // MARK: - EventTracking
 
-    /**
-     Tracks an analytics action or event.
-
-     - parameter event:      The event that occurred.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks an analytics action or event.
+    ///
+    /// - Parameters:
+    ///   - event: The event that occurred.
+    ///   - properties: The optional additional properties.
     public static func track(event: String, withAdditionalProperties properties: Properties? = nil) {
         engine.track(event: event, withAdditionalProperties: properties)
     }
 
-    /**
-     Tracks the event.
-
-     - parameter event:      The event to track.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks the event.
+    ///
+    /// - Parameters:
+    ///   - event: The event to track.
+    ///   - properties: The optional additional properties.
     func track(event: String, withAdditionalProperties properties: Properties? = nil) {
         let providers: [EventTracking] = findProviders()
 
@@ -245,25 +225,23 @@ public final class Simcoe {
 
     // MARK: - LifetimeValueIncreasing
 
-    /**
-     Tracks the lifetime value increase.
-
-     - parameter amount:     The amount to increase that lifetime value for.
-     - parameter item:       The optional item to extend.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks the lifetime value increase.
+    ///
+    /// - Parameters:
+    ///   - amount: The amount to increase that lifetime value for.
+    ///   - item: The optional item to extend.
+    ///   - properties: The optional additional properties.
     public static func trackLifetimeIncrease(byAmount amount: Double = 1, forItem item: String? = nil,
                                                       withAdditionalProperties properties: Properties? = nil) {
         engine.trackLifetimeIncrease(byAmount: amount, forItem: item, withAdditionalProperties: properties)
     }
 
-    /**
-     Tracks the lifetime value increase.
-
-     - parameter amount:     The amount to increase that lifetime value for.
-     - parameter item:       The optional item to extend.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks the lifetime value increase.
+    ///
+    /// - Parameters:
+    ///   - amount: The amount to increase that lifetime value for.
+    ///   - item: The optional item to extend.
+    ///   - properties: The optional additional properties.
     func trackLifetimeIncrease(byAmount amount: Double = 1, forItem item: String? = nil,
                                         withAdditionalProperties properties: Properties? = nil) {
         let providers: [LifetimeValueIncreasing] = findProviders()
@@ -276,22 +254,20 @@ public final class Simcoe {
 
     // MARK: - LocationTracking
 
-    /**
-     Tracks a user's location.
-
-     - parameter location:   The user's location.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks location.
+    ///
+    /// - Parameters:
+    ///   - location: The location to track.
+    ///   - properties: The optional additional properties.
     public static func track(location: CLLocation, withAdditionalProperties properties: Properties?) {
         engine.track(location: location, withAdditionalProperties: properties)
     }
 
-    /**
-     Tracks a user's location.
-
-     - parameter location:   The user's location.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks location.
+    ///
+    /// - Parameters:
+    ///   - location: The location to track.
+    ///   - properties: The optional additional properties.
     func track(location: CLLocation, withAdditionalProperties properties: Properties?) {
         let providers: [LocationTracking] = findProviders()
 
@@ -302,22 +278,20 @@ public final class Simcoe {
 
     // MARK: - PageViewTracking
 
-    /**
-     Tracks a page view.
-
-     - parameter pageView:   The page view event.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks the page view.
+    ///
+    /// - Parameters:
+    ///   - pageView: The page view to track.
+    ///   - properties: The optional additional properties.
     public static func track(pageView: String, withAdditionalProperties properties: Properties? = nil) {
         engine.track(pageView: pageView, withAdditionalProperties: properties)
     }
 
-    /**
-     Tracks the page view.
-
-     - parameter pageView:   The page view to track.
-     - parameter properties: The optional additional properties.
-     */
+    /// Tracks the page view.
+    ///
+    /// - Parameters:
+    ///   - pageView: The page view to track.
+    ///   - properties: The optional additional properties.
     func track(pageView: String, withAdditionalProperties properties: Properties? = nil) {
         let providers: [PageViewTracking] = findProviders()
 
@@ -330,20 +304,18 @@ public final class Simcoe {
 
     /// Tracks a purchase event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties
     public static func trackPurchaseEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) {
         engine.trackPurchaseEvent(products, eventProperties: eventProperties)
     }
 
     /// Tracks a purchase event.
     ///
-    /// - parameter products: The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties
     func trackPurchaseEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) {
         let providers: [PurchaseTracking] = findProviders()
         let propertiesString = eventProperties != nil ? "=> \(eventProperties!.description)" : ""
@@ -361,22 +333,20 @@ public final class Simcoe {
 
     // MARK: - UserAttributeTracking
 
-    /**
-     Sets the User Attribute.
-
-     - parameter key:   The key of the user attribute
-     - parameter value: the value of the user attribute
-     */
+    /// Sets the User Attribute.
+    ///
+    /// - Parameters:
+    ///   - key: The attribute key to log.
+    ///   - value: The attribute value to log.
     public static func setUserAttribute(_ key: String, value: Any) {
         engine.setUserAttribute(key, value: value)
     }
 
-    /**
-     Sets the User Attribute.
-
-     - parameter key:   The key of the user attribute
-     - parameter value: the value of the user attribute
-     */
+    /// Sets the User Attribute.
+    ///
+    /// - Parameters:
+    ///   - key: The attribute key to log.
+    ///   - value: The attribute value to log.
     func setUserAttribute(_ key: String, value: Any) {
         let providers: [UserAttributeTracking] = findProviders()
         
@@ -389,20 +359,18 @@ public final class Simcoe {
 
     /// Logs the action of viewing a product's details.
     ///
-    /// - parameter product: The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
     public static func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) {
         engine.logViewDetail(product, eventProperties: eventProperties)
     }
 
     /// Logs the action of viewing a product's details.
     ///
-    /// - parameter product: The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
     func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) {
         let providers: [ViewDetailLogging] = findProviders()
         let simcoeProduct = product.toSimcoeProduct()

--- a/Simcoe/SimcoeProduct.swift
+++ b/Simcoe/SimcoeProduct.swift
@@ -8,6 +8,7 @@
 
 /// The product.
 public struct SimcoeProduct {
+
     /// The product name.
     public let productName: String
 
@@ -25,13 +26,12 @@ public struct SimcoeProduct {
 
     /// The default initializer.
     ///
-    /// - parameter productName: The product name.
-    /// - parameter productId:   The product Id.
-    /// - parameter quantity:    The quantity.
-    /// - parameter price:       The price.
-    /// - parameter properties:  The properties.
-    ///
-    /// - returns: A Product instance.
+    /// - Parameters:
+    ///   - productName: The product name.
+    ///   - productId: The product Id.
+    ///   - quantity: The quantity.
+    ///   - price: The price.
+    ///   - properties: The properties.
     public init(productName: String,
                 productId: String,
                 quantity: Int,

--- a/Simcoe/SimcoeProductConvertible.swift
+++ b/Simcoe/SimcoeProductConvertible.swift
@@ -11,7 +11,7 @@ public protocol SimcoeProductConvertible {
 
     /// Converts a product to a Simcoe Product.
     ///
-    /// - returns: A SimcoeProduct
+    /// - Returns: A SimcoeProduct
     func toSimcoeProduct() -> SimcoeProduct
     
 }

--- a/Simcoe/Tracker.swift
+++ b/Simcoe/Tracker.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/// A recorder for SimcoeEvents
+/// A recorder for SimcoeEvents.
 public final class Tracker {
 
     /// The output option for the recorder. Defaults to .Verbose.
@@ -20,21 +20,17 @@ public final class Tracker {
 
     fileprivate let outputSources: [Output]
 
-    /**
-     Initializes a new instance using the specified source as its output. By default, this is the
-     standard output console.
-
-     - parameter outputSource: The source to use for general output.
-     */
+    /// Initializes a new instance using the specified source as its output. By default, this is the
+    /// standard output console.
+    ///
+    /// - Parameter outputSources: The source to use for general output.
     init(outputSources: [Output] = [ConsoleOutput(), RemoteOutput(token: Simcoe.session)]) {
         self.outputSources = outputSources
     }
 
-    /**
-     Records the event.
-
-     - parameter event: The event to record.
-     */
+    /// Records the event.
+    ///
+    /// - Parameter event: The event to record.
     func track(event: Event) {
         events.append(event)
         parseEvent(event)

--- a/Simcoe/TrackingResult.swift
+++ b/Simcoe/TrackingResult.swift
@@ -6,12 +6,10 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-/**
- A result of an analytics tracking operation.
-
- - Success: The operation was successfully logged to the analytics provider.
- - Error:   An error occurred while logging to the analytics provider; the message value indicates a human-readable description of why that error occurred.
- */
+/// A result of an analytics tracking operation.
+///
+/// - success: The operation was successfully logged to the analytics provider.
+/// - error: An error occurred while logging to the analytics provider; the message value indicates a human-readable description of why that error occurred.
 public enum TrackingResult {
 
     case success

--- a/Simcoe/mParticle/MPCommerceEvent+Simcoe.swift
+++ b/Simcoe/mParticle/MPCommerceEvent+Simcoe.swift
@@ -12,11 +12,10 @@ extension MPCommerceEvent {
 
     /// A convenience initializer for MPCommerceEvent.
     ///
-    /// - parameter eventType:       The event type.
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A MPCommerceEvent instance.
+    /// - Parameters:
+    ///   - eventType: The event type.
+    ///   - products: The products.
+    ///   - eventProperties: The event properties.
     internal convenience init(eventType: MPCommerceEventAction,
                               products: [MPProduct],
                               eventProperties: Properties?) {

--- a/Simcoe/mParticle/MPCommerceEventKeys.swift
+++ b/Simcoe/mParticle/MPCommerceEventKeys.swift
@@ -8,15 +8,15 @@
 
 /// The MPCommerceEvent keys available to use with eventProperties.
 ///
-/// - CheckoutOptions:       The checkout options.
-/// - CheckoutStep:          The checkout step.
-/// - Currency:              The currency.
-/// - NonInteractive:        The non interactive flag.
-/// - PromotionContainer:    The promotion container.
-/// - ProductListName:       The product list name.
-/// - ProductListSource:     The product list source.
-/// - ScreenName:            The screen name.
-/// - TransactionAttributes: The transactions attributes.
+/// - checkoutOptions: The checkout options.
+/// - checkoutStep: The checkout step.
+/// - currency: The currency.
+/// - nonInteractive: The non interactive flag.
+/// - promotionContainer: The promotion container.
+/// - productListName: The product list name.
+/// - productListSource: The product list source.
+/// - screenName: The screen name.
+/// - transactionAttributes: The transactions attributes.
 public enum MPCommerceEventKeys: String, EnumerationListable {
 
     case checkoutOptions = "checkoutOptions"

--- a/Simcoe/mParticle/MPEvent+Simcoe.swift
+++ b/Simcoe/mParticle/MPEvent+Simcoe.swift
@@ -10,35 +10,33 @@ import mParticle_Apple_SDK
 
 extension MPEvent {
 
-    /**
-     Creates a dictionary used to generate an MPEvent object. All of the input parameters map to
-     properties on the MPEvent object. Not setting any of the properties will not initialize those respective
-     properties of the MPEvent object.
-
-     The `info` parameter will generate additional key / value pairs into the root level of the dictionary.
-
-     It is safe to additionally add key / values into the root of the dictionary; any key / values passed in that
-     are not recognized will be set in the info dictionary of the generated MPEvent object.
-
-     - parameter type:        The event type. Required.
-     - parameter name:        The event name. Required.
-     - parameter category:    The category of the event. Optional.
-     - parameter duration:    The duration of the event. Optional.
-     - parameter startTime:   The start time of the event. Optional.
-     - parameter endTime:     The end time of the event. Optional.
-     - parameter customFlags: The custom flags for the event. Optional.
-     - parameter info:        Additional key / value pairs to place into the root level of the dictionary. These will
-     map to the `info` dictionary of the generated MPEvent object.
-
-     - returns: A dictionary containing the information for generating an MPEvent.
-     */
+    /// Creates a dictionary used to generate an MPEvent object. All of the input parameters map to
+    /// properties on the MPEvent object. Not setting any of the properties will not initialize those respective
+    /// properties of the MPEvent object.
+    ///
+    /// The `info` parameter will generate additional key / value pairs into the root level of the dictionary.
+    ///
+    /// It is safe to additionally add key / values into the root of the dictionary; any key / values passed in that
+    /// are not recognized will be set in the info dictionary of the generated MPEvent object.
+    ///
+    /// - Parameters:
+    ///   - type: The event type. Required.
+    ///   - name: The event name. Required.
+    ///   - category: The category of the event. Optional.
+    ///   - duration: The duration of the event. Optional.
+    ///   - startTime: The start time of the event. Optional.
+    ///   - endTime: The end time of the event. Optional.
+    ///   - customFlags: The custom flags for the event. Optional.
+    ///   - info: Additional key / value pairs to place into the root level of the dictionary. These will
+    ///     map to the `info` dictionary of the generated MPEvent object.
+    /// - Returns: A dictionary containing the information for generating an MPEvent.
     public static func eventData(type: MPEventType, name: String, category: String? = nil,
                                duration: Float? = nil, startTime: Date? = nil,
                                endTime: Date? = nil, customFlags: [String: [String]]? = nil,
                                info: Properties? = nil) -> Properties {
         var properties = Properties()
 
-        properties[MPEventKeys.eventType.rawValue] = type.rawValue as String
+        properties[MPEventKeys.eventType.rawValue] = type.rawValue as UInt
         properties[MPEventKeys.name.rawValue] = name as String
 
         if let category = category {
@@ -70,14 +68,11 @@ extension MPEvent {
         return properties
     }
 
-
     /// Generates a MPEvent object based on the passed in Properties.
     ///
-    /// - parameter data: The properties.
-    ///
-    /// - throws: MPEventGenerationError
-    ///
-    /// - returns: A MPEvent.
+    /// - Parameter data: The properties.
+    /// - Returns: A MPEvent.
+    /// - Throws: MPEventGenerationError
     internal static func toEvent(usingData data: Properties) throws -> MPEvent {
         guard let name = data[MPEventKeys.name.rawValue] as? String else {
             throw MPEventGenerationError.nameMissing
@@ -97,7 +92,7 @@ extension MPEvent {
         }
 
         if let duration = data[MPEventKeys.duration.rawValue] as? Float {
-            event.duration = duration
+            event.duration = NSNumber(value: duration)
         }
 
         if let startTime = data[MPEventKeys.startTime.rawValue] as? Date {

--- a/Simcoe/mParticle/MPEvent+Simcoe.swift
+++ b/Simcoe/mParticle/MPEvent+Simcoe.swift
@@ -56,7 +56,7 @@ extension MPEvent {
         }
 
         if let customFlags = customFlags {
-            properties[MPEventKeys.customFlags.rawValue] = customFlags as [String: [String]]
+            properties[MPEventKeys.customFlags.rawValue] = customFlags
         }
 
         if let info = info {

--- a/Simcoe/mParticle/MPEvent+Simcoe.swift
+++ b/Simcoe/mParticle/MPEvent+Simcoe.swift
@@ -36,29 +36,29 @@ extension MPEvent {
                                duration: Float? = nil, startTime: Date? = nil,
                                endTime: Date? = nil, customFlags: [String: [String]]? = nil,
                                info: Properties? = nil) -> Properties {
-        var properties: Properties = [MPEventKeys.eventType.rawValue: type.rawValue as AnyObject]
+        var properties = Properties()
 
-        properties[MPEventKeys.eventType.rawValue] = type.rawValue as AnyObject
-        properties[MPEventKeys.name.rawValue] = name as AnyObject
+        properties[MPEventKeys.eventType.rawValue] = type.rawValue as String
+        properties[MPEventKeys.name.rawValue] = name as String
 
         if let category = category {
-            properties[MPEventKeys.category.rawValue] = category as AnyObject
+            properties[MPEventKeys.category.rawValue] = category as String
         }
 
         if let duration = duration {
-            properties[MPEventKeys.duration.rawValue] = duration as AnyObject
+            properties[MPEventKeys.duration.rawValue] = duration as Float
         }
 
         if let startTime = startTime {
-            properties[MPEventKeys.startTime.rawValue] = startTime as AnyObject
+            properties[MPEventKeys.startTime.rawValue] = startTime as Date
         }
 
         if let endTime = endTime {
-            properties[MPEventKeys.endTime.rawValue] = endTime as AnyObject
+            properties[MPEventKeys.endTime.rawValue] = endTime as Date
         }
 
         if let customFlags = customFlags {
-            properties[MPEventKeys.customFlags.rawValue] = customFlags as AnyObject
+            properties[MPEventKeys.customFlags.rawValue] = customFlags as [String: [String]]
         }
 
         if let info = info {
@@ -97,7 +97,7 @@ extension MPEvent {
         }
 
         if let duration = data[MPEventKeys.duration.rawValue] as? Float {
-            event.duration = duration as NSNumber
+            event.duration = duration
         }
 
         if let startTime = data[MPEventKeys.startTime.rawValue] as? Date {

--- a/Simcoe/mParticle/MPEvent+Simcoe.swift
+++ b/Simcoe/mParticle/MPEvent+Simcoe.swift
@@ -36,23 +36,23 @@ extension MPEvent {
                                info: Properties? = nil) -> Properties {
         var properties = Properties()
 
-        properties[MPEventKeys.eventType.rawValue] = type.rawValue as UInt
-        properties[MPEventKeys.name.rawValue] = name as String
+        properties[MPEventKeys.eventType.rawValue] = type.rawValue
+        properties[MPEventKeys.name.rawValue] = name
 
         if let category = category {
-            properties[MPEventKeys.category.rawValue] = category as String
+            properties[MPEventKeys.category.rawValue] = category
         }
 
         if let duration = duration {
-            properties[MPEventKeys.duration.rawValue] = duration as Float
+            properties[MPEventKeys.duration.rawValue] = duration
         }
 
         if let startTime = startTime {
-            properties[MPEventKeys.startTime.rawValue] = startTime as Date
+            properties[MPEventKeys.startTime.rawValue] = startTime
         }
 
         if let endTime = endTime {
-            properties[MPEventKeys.endTime.rawValue] = endTime as Date
+            properties[MPEventKeys.endTime.rawValue] = endTime
         }
 
         if let customFlags = customFlags {

--- a/Simcoe/mParticle/MPEventGenerationError.swift
+++ b/Simcoe/mParticle/MPEventGenerationError.swift
@@ -8,9 +8,9 @@
 
 /// The MPEvent generation error types.
 ///
-/// - NameMissing:     The name missing error.
-/// - TypeMissing:     The type missing error.
-/// - EventInitFailed: The event init failed error.
+/// - nameMissing: The name missing error.
+/// - typeMissing: The type missing error.
+/// - eventInitFailed: The event init failed error.
 internal enum MPEventGenerationError: Error {
 
     case nameMissing

--- a/Simcoe/mParticle/MPEventKeys.swift
+++ b/Simcoe/mParticle/MPEventKeys.swift
@@ -8,13 +8,13 @@
 
 /// The MPEvent keys.
 ///
-/// - EventType:    The event type.
-/// - Category:     The category.
-/// - Duration:     The duration.
-/// - StartTime:    The start time.
-/// - EndTime:      The end time.
-/// - Name:         The name.
-/// - CustomFlags:  The custom flags.
+/// - eventType: The event type.
+/// - category: The category.
+/// - duration: The duration.
+/// - startTime: The start time.
+/// - endTime: The end time.
+/// - name: The name.
+/// - customFlags: The custom flags.
 public enum MPEventKeys: String, EnumerationListable {
 
     case eventType = "SimcoeInternalMPEventType"

--- a/Simcoe/mParticle/MPProduct+Simcoe.swift
+++ b/Simcoe/mParticle/MPProduct+Simcoe.swift
@@ -20,8 +20,8 @@ extension MPProduct {
         self.init(name: simcoeProduct.productName,
                   // INTENTIONAL: In MPProduct: SKU of a product. This is the product id
                   sku: simcoeProduct.productId,
-                  quantity: NSNumber(value: simcoeProduct.quantity),
-                  price: NSNumber(value: simcoeProduct.price ?? 0))
+                  quantity: simcoeProduct.quantity,
+                  price: simcoeProduct.price ?? nil)
 
         guard let properties = simcoeProduct.properties else {
             return

--- a/Simcoe/mParticle/MPProduct+Simcoe.swift
+++ b/Simcoe/mParticle/MPProduct+Simcoe.swift
@@ -12,16 +12,14 @@ extension MPProduct {
 
     /// A convenience initializer.
     ///
-    /// - parameter product: A SimcoeProductConvertible instance.
-    ///
-    /// - returns: A MPProduct.
+    /// - Parameter product: A SimcoeProductConvertible instance.
     internal convenience init(product: SimcoeProductConvertible) {
         let simcoeProduct = product.toSimcoeProduct()
         self.init(name: simcoeProduct.productName,
                   // INTENTIONAL: In MPProduct: SKU of a product. This is the product id
                   sku: simcoeProduct.productId,
-                  quantity: simcoeProduct.quantity,
-                  price: simcoeProduct.price ?? nil)
+                  quantity: NSNumber(value: simcoeProduct.quantity),
+                  price: NSNumber(value: simcoeProduct.price ?? 0))
 
         guard let properties = simcoeProduct.properties else {
             return

--- a/Simcoe/mParticle/MPProductKeys.swift
+++ b/Simcoe/mParticle/MPProductKeys.swift
@@ -8,12 +8,12 @@
 
 /// The MPProduct keys available for use with additionalProperties.
 ///
-/// - Brand:      The product brand.
-/// - Category:   A category to which the product belongs.
-/// - CouponCode: The coupon associated with the product.
-/// - Sku:        The sku of the product.
-/// - Position:   The position of the product on the screen or impression list.
-/// - Variant:    The variant.
+/// - brand: The product brand.
+/// - category: A category to which the product belongs.
+/// - couponCode: The coupon associated with the product.
+/// - sku: The sku of the product.
+/// - position: The position of the product on the screen or impression list.
+/// - variant: The variant.
 public enum MPProductKeys: String, EnumerationListable {
 
     case brand = "brand"

--- a/Simcoe/mParticle/MPTransactionAttributes+Simcoe.swift
+++ b/Simcoe/mParticle/MPTransactionAttributes+Simcoe.swift
@@ -25,15 +25,15 @@ extension MPTransactionAttributes {
         }
 
         if let revenue = properties[MPTransactionAttributesKeys.revenue.rawValue] as? Double {
-            self.revenue = revenue
+            self.revenue = NSNumber(value: revenue)
         }
 
         if let shipping = properties[MPTransactionAttributesKeys.shipping.rawValue] as? Double {
-            self.shipping = shipping
+            self.shipping = NSNumber(value: shipping)
         }
 
         if let tax = properties[MPTransactionAttributesKeys.tax.rawValue] as? Double {
-            self.tax = tax
+            self.tax = NSNumber(value: tax)
         }
 
         if let transactionId = properties[MPTransactionAttributesKeys.transactionId.rawValue] as? String {

--- a/Simcoe/mParticle/MPTransactionAttributes+Simcoe.swift
+++ b/Simcoe/mParticle/MPTransactionAttributes+Simcoe.swift
@@ -25,15 +25,15 @@ extension MPTransactionAttributes {
         }
 
         if let revenue = properties[MPTransactionAttributesKeys.revenue.rawValue] as? Double {
-            self.revenue = revenue as NSNumber
+            self.revenue = revenue
         }
 
         if let shipping = properties[MPTransactionAttributesKeys.shipping.rawValue] as? Double {
-            self.shipping = shipping as NSNumber
+            self.shipping = shipping
         }
 
         if let tax = properties[MPTransactionAttributesKeys.tax.rawValue] as? Double {
-            self.tax = tax as NSNumber
+            self.tax = tax
         }
 
         if let transactionId = properties[MPTransactionAttributesKeys.transactionId.rawValue] as? String {

--- a/Simcoe/mParticle/MPTransactionAttributesKeys.swift
+++ b/Simcoe/mParticle/MPTransactionAttributesKeys.swift
@@ -8,12 +8,12 @@
 
 /// The MPTransactionAttributes keys available.
 ///
-/// - Affiliation: The affiliation.
-/// - CouponCode: The coupon code.
-/// - Revenue: The revenue amount.
-/// - Shipping: The shipping amount.
-/// - Tax: The tax amount.
-/// - TransactionId: The transaction Id.
+/// - affiliation: The affiliation.
+/// - couponCode: The coupon code.
+/// - revenue: The revenue amount.
+/// - shipping: The shipping amount.
+/// - tax: The tax amount.
+/// - transactionId: The transaction Id.
 public enum MPTransactionAttributesKeys: String, EnumerationListable {
 
     case affiliation = "affiliation"

--- a/Simcoe/mParticle/README.md
+++ b/Simcoe/mParticle/README.md
@@ -43,9 +43,9 @@ For `EventTracking` and `LocationTracking`, mParticle expects an `MPEvent` objec
 
 ```swift
 public func eventData(type type: MPEventType, name: String, category: String? = nil,
-    duration: Float? = nil, startTime: NSDate? = nil,
-    endTime: NSDate? = nil, customFlags: [String: [String]]? = nil,
-    info: [String: AnyObject]? = nil) -> [String: AnyObject]
+    duration: Float? = nil, startTime: Date? = nil,
+    endTime: Date? = nil, customFlags: [String: [String]]? = nil,
+    info: Properties? = nil) -> Properties
 ```
 
 The two mandatory items for every `MPEvent` object are `type` and `name`, both of which are non-optional parameters. All other items of `MPEvent` are optional

--- a/Simcoe/mParticle/mParticle.swift
+++ b/Simcoe/mParticle/mParticle.swift
@@ -151,7 +151,7 @@ extension mParticle: EventTracking {
             return .error(message: "Cannot track an event without valid properties.")
         }
 
-        properties[MPEventKeys.name.rawValue] = event as String
+        properties[MPEventKeys.name.rawValue] = event
 
         let event: MPEvent
         do {

--- a/Simcoe/mParticle/mParticle.swift
+++ b/Simcoe/mParticle/mParticle.swift
@@ -9,7 +9,16 @@
 import mParticle_Apple_SDK
 
 /// Simcoe Analytics handler for the MParticle iOS SDK.
-open class mParticle {
+open class mParticle: CartLogging,
+                      CheckoutTracking,
+                      ErrorLogging,
+                      EventTracking,
+                      LifetimeValueIncreasing,
+                      LocationTracking,
+                      PageViewTracking,
+                      PurchaseTracking,
+                      UserAttributeTracking,
+                      ViewDetailLogging {
 
     fileprivate static let unknownErrorMessage = "An unknown error occurred."
 
@@ -42,11 +51,7 @@ open class mParticle {
         MParticle.sharedInstance().start()
     }
 
-}
-
-// MARK: - CartLogging
-
-extension mParticle: CartLogging {
+    // MARK: - CartLogging
 
     /// Logs the addition of a product to the cart.
     ///
@@ -54,7 +59,7 @@ extension mParticle: CartLogging {
     ///   - product: The SimcoeProductConvertible instance.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    public func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
+    open func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .addToCart,
                                     products: [mPProduct],
@@ -71,7 +76,7 @@ extension mParticle: CartLogging {
     ///   - product: The SimcoeProductConvertible instance.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    public func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
+    open func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .removeFromCart,
                                     products: [mPProduct],
@@ -81,12 +86,8 @@ extension mParticle: CartLogging {
 
         return .success
     }
-    
-}
 
-// MARK: - CheckoutTracking
-
-extension mParticle: CheckoutTracking {
+    // MARK: - CheckoutTracking
 
     /// Tracks a checkout event.
     ///
@@ -94,7 +95,7 @@ extension mParticle: CheckoutTracking {
     ///   - products: The products.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    public func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
+    open func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         let mPProducts = products.map { MPProduct(product: $0) }
         let event = MPCommerceEvent(eventType: .checkout,
                                     products: mPProducts,
@@ -105,11 +106,7 @@ extension mParticle: CheckoutTracking {
         return .success
     }
 
-}
-
-// MARK: - ErrorLogging
-
-extension mParticle: ErrorLogging {
+    // MARK: - ErrorLogging
 
     /// Logs an error through mParticle.
     ///
@@ -120,17 +117,13 @@ extension mParticle: ErrorLogging {
     ///   - error: The error to log.
     ///   - properties: The properties of the event.
     /// - Returns: A tracking result.
-    public func log(error: String, withAdditionalProperties properties: Properties? = nil) -> TrackingResult {
+    open func log(error: String, withAdditionalProperties properties: Properties? = nil) -> TrackingResult {
         MParticle.sharedInstance().logError(error, eventInfo: properties)
 
         return .success
     }
 
-}
-
-// MARK: - EventTracking
-
-extension mParticle: EventTracking {
+    // MARK: - EventTracking
 
     /// Tracks an mParticle event.
     ///
@@ -146,7 +139,7 @@ extension mParticle: EventTracking {
     ///   - event: The event name to log.
     ///   - properties: The properties of the event.
     /// - Returns: A tracking result.
-    public func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    open func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         guard var properties = properties else {
             return .error(message: "Cannot track an event without valid properties.")
         }
@@ -167,11 +160,7 @@ extension mParticle: EventTracking {
         return .success
     }
 
-}
-
-// MARK: - LifetimeValueIncreasing
-
-extension mParticle: LifetimeValueIncreasing {
+    // MARK: - LifetimeValueIncreasing
 
     /// Increases the lifetime value of the key by the specified amount.
     ///
@@ -180,18 +169,14 @@ extension mParticle: LifetimeValueIncreasing {
     ///   - item: The optional item to extend.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?,
-                                               withAdditionalProperties properties: Properties?) -> TrackingResult {
+    open func increaseLifetimeValue(byAmount amount: Double, forItem item: String?,
+                                      withAdditionalProperties properties: Properties?) -> TrackingResult {
         MParticle.sharedInstance().logLTVIncrease(amount, eventName: (item ?? ""), eventInfo: properties)
 
         return .success
     }
-    
-}
 
-// MARK: - LocationTracking
-
-extension mParticle: LocationTracking {
+    // MARK: - LocationTracking
 
     /// Tracks the user's location.
     ///
@@ -206,7 +191,7 @@ extension mParticle: LocationTracking {
     ///   - location: The location data being tracked.
     ///   - properties: The properties for the MPEvent.
     /// - Returns: A tracking result.
-    public func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    open func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
         var eventProperties = properties ?? Properties() // TODO: Handle Error
         eventProperties["latitude"] = String(location.coordinate.latitude)
         eventProperties["longitude"] = String(location.coordinate.longitude)
@@ -225,11 +210,7 @@ extension mParticle: LocationTracking {
         return .success
     }
 
-}
-
-// MARK: - PageViewTracking
-
-extension mParticle: PageViewTracking {
+    // MARK: - PageViewTracking
 
     /// Tracks the page view.
     ///
@@ -237,17 +218,13 @@ extension mParticle: PageViewTracking {
     ///   - pageView: The page view to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    public func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    open func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         MParticle.sharedInstance().logScreen(pageView, eventInfo: properties)
 
         return .success
     }
-    
-}
 
-// MARK: - PurchaseTracking
-
-extension mParticle: PurchaseTracking {
+    // MARK: - PurchaseTracking
 
     /// Tracks a purchase event.
     ///
@@ -255,7 +232,7 @@ extension mParticle: PurchaseTracking {
     ///   - products: The products.
     ///   - eventProperties: The event properties
     /// - Returns: A tracking result.
-    public func trackPurchaseEvent<T : SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
+    open func trackPurchaseEvent<T : SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         let mPProducts = products.map { MPProduct(product: $0) }
         let event = MPCommerceEvent(eventType: .purchase,
                                     products: mPProducts,
@@ -265,31 +242,22 @@ extension mParticle: PurchaseTracking {
 
         return .success
     }
-    
-}
 
+    // MARK: - UserAttributeTracking
 
-// MARK: - UserAttributeTracking
-
-extension mParticle: UserAttributeTracking {
-    
     /// Sets the User Attribute.
     ///
     /// - Parameters:
     ///   - key: The attribute key to log.
     ///   - value: The attribute value to log.
     /// - Returns: A tracking result.
-    public func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
+    open func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         MParticle.sharedInstance().setUserAttribute(key, value: value)
 
         return .success
     }
-    
-}
 
-// MARK: - ViewDetailLogging
-
-extension mParticle: ViewDetailLogging {
+    // MARK: - ViewDetailLogging
 
     /// Logs the action of viewing a product's details.
     ///
@@ -297,7 +265,7 @@ extension mParticle: ViewDetailLogging {
     ///   - product: The SimcoeProductConvertible instance.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    public func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
+    open func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .viewDetail,
                                     products: [mPProduct],
@@ -307,5 +275,5 @@ extension mParticle: ViewDetailLogging {
 
         return .success
     }
-    
+
 }

--- a/Simcoe/mParticle/mParticle.swift
+++ b/Simcoe/mParticle/mParticle.swift
@@ -16,17 +16,14 @@ open class mParticle {
     /// The name of the tracker.
     open let name = "mParticle"
 
-    /**
-     Initializes and starts the SDK with the input key and secret.
-
-     - parameter key:              The key.
-     - parameter secret:           The secret.
-     - parameter installationType: The installation type.
-     - parameter environment:      The environment.
-     - parameter proxyAppDelegate: Determines if app delegate proxy should be used.
-
-     - returns: A mParticle instance.
-     */
+    /// Initializes and starts the SDK with the input key and secret.
+    ///
+    /// - Parameters:
+    ///   - key: The key.
+    ///   - secret: The secret.
+    ///   - installationType: The installation type.
+    ///   - environment: The environment.
+    ///   - proxyAppDelegate: Determines if app delegate proxy should be used.
     public init(key: String,
                 secret: String,
                 installationType: MPInstallationType = .autodetect,
@@ -53,10 +50,10 @@ extension mParticle: CartLogging {
 
     /// Logs the addition of a product to the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     public func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .addToCart,
@@ -70,10 +67,10 @@ extension mParticle: CartLogging {
 
     /// Logs the removal of a product from the cart.
     ///
-    /// - parameter product:         The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     public func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .removeFromCart,
@@ -93,10 +90,10 @@ extension mParticle: CheckoutTracking {
 
     /// Tracks a checkout event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     public func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         let mPProducts = products.map { MPProduct(product: $0) }
         let event = MPCommerceEvent(eventType: .checkout,
@@ -114,15 +111,15 @@ extension mParticle: CheckoutTracking {
 
 extension mParticle: ErrorLogging {
 
-    /**
-     Logs an error through mParticle.
-
-     It is recommended that you use the `Simcoe.eventData()` function in order to generate the properties
-     dictionary properly.
-
-     - parameter error:      The error to log.
-     - parameter properties: The properties of the event.
-     */
+    /// Logs an error through mParticle.
+    ///
+    /// It is recommended that you use the `Simcoe.eventData()` function in order to generate the properties
+    /// dictionary properly.
+    ///
+    /// - Parameters:
+    ///   - error: The error to log.
+    ///   - properties: The properties of the event.
+    /// - Returns: A tracking result.
     public func log(error: String, withAdditionalProperties properties: Properties? = nil) -> TrackingResult {
         MParticle.sharedInstance().logError(error, eventInfo: properties)
 
@@ -135,20 +132,20 @@ extension mParticle: ErrorLogging {
 
 extension mParticle: EventTracking {
 
-    /**
-     Tracks an mParticle event.
-
-     Internally, this generates an MPEvent object based on the properties passed in. The event string
-     passed as the first parameter is delineated as the .name of the MPEvent. As a caller, you are
-     required to pass in non-nil properties where one of the properties is the MPEventType. Failure
-     to do so will cause this function to fail.
-
-     It is recommended that you use the `Simcoe.eventData()` function in order to generate the properties
-     dictionary properly.
-
-     - parameter event:      The event name to log.
-     - parameter properties: The properties of the event.
-     */
+    /// Tracks an mParticle event.
+    ///
+    /// Internally, this generates an MPEvent object based on the properties passed in. The event string
+    /// passed as the first parameter is delineated as the .name of the MPEvent. As a caller, you are
+    /// required to pass in non-nil properties where one of the properties is the MPEventType. Failure
+    /// to do so will cause this function to fail.
+    ///
+    /// It is recommended that you use the `Simcoe.eventData()` function in order to generate the properties
+    /// dictionary properly.
+    ///
+    /// - Parameters:
+    ///   - event: The event name to log.
+    ///   - properties: The properties of the event.
+    /// - Returns: A tracking result.
     public func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         guard var properties = properties else {
             return .error(message: "Cannot track an event without valid properties.")
@@ -176,15 +173,13 @@ extension mParticle: EventTracking {
 
 extension mParticle: LifetimeValueIncreasing {
 
-    /**
-     Increases the lifetime value of the key by the specified amount.
-
-     - parameter amount:     The amount to increase that lifetime value for.
-     - parameter item:       The optional item to extend.
-     - parameter properties: The optional additional properties.
-
-     - returns: A tracking result.
-     */
+    /// Increases the lifetime value of the key by the specified amount.
+    ///
+    /// - Parameters:
+    ///   - amount: The amount to increase that lifetime value for.
+    ///   - item: The optional item to extend.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?,
                                                withAdditionalProperties properties: Properties?) -> TrackingResult {
         MParticle.sharedInstance().logLTVIncrease(amount, eventName: (item ?? ""), eventInfo: properties)
@@ -198,20 +193,19 @@ extension mParticle: LifetimeValueIncreasing {
 
 extension mParticle: LocationTracking {
 
-    /**
-     Tracks the user's location.
-
-     Internally, this generates an MPEvent object based on the properties passed in. As a result, it is
-     required that the properties dictionary not be nil and contains keys for .name and .eventType. The latitude
-     and longitude of the location object passed in will automatically be added to the info dictionary of the MPEvent
-     object; it is recommended not to include them manually unless there are other properties required to use them.
-
-     It is recommended that you use the `Simcoe.eventData()` function in order to generate the properties
-     dictionary properly.
-
-     - parameter location:   The location data being tracked.
-     - parameter properties: The properties for the MPEvent.
-     */
+    /// Tracks the user's location.
+    ///
+    /// Internally, this generates an MPEvent object based on the properties passed in. As a result, it is
+    /// required that the properties dictionary not be nil and contains keys for .name and .eventType. The latitude
+    /// and longitude of the location object passed in will automatically be added to the info dictionary of the MPEvent
+    /// object; it is recommended not to include them manually unless there are other properties required to use them.
+    ///
+    /// It is recommended that you use the `Simcoe.eventData()` function in order to generate the properties
+    /// dictionary properly.
+    /// - Parameters:
+    ///   - location: The location data being tracked.
+    ///   - properties: The properties for the MPEvent.
+    /// - Returns: A tracking result.
     public func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
         var eventProperties = properties ?? Properties() // TODO: Handle Error
         eventProperties["latitude"] = String(location.coordinate.latitude)
@@ -237,13 +231,12 @@ extension mParticle: LocationTracking {
 
 extension mParticle: PageViewTracking {
 
-    /**
-     Tracks the page view.
-
-     - parameter pageView: The page view to track.
-
-     - returns: A tracking result.
-     */
+    /// Tracks the page view.
+    ///
+    /// - Parameters:
+    ///   - pageView: The page view to track.
+    ///   - properties: The optional additional properties.
+    /// - Returns: A tracking result.
     public func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         MParticle.sharedInstance().logScreen(pageView, eventInfo: properties)
 
@@ -258,10 +251,10 @@ extension mParticle: PurchaseTracking {
 
     /// Tracks a purchase event.
     ///
-    /// - parameter products:        The products.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - products: The products.
+    ///   - eventProperties: The event properties
+    /// - Returns: A tracking result.
     public func trackPurchaseEvent<T : SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         let mPProducts = products.map { MPProduct(product: $0) }
         let event = MPCommerceEvent(eventType: .purchase,
@@ -280,12 +273,12 @@ extension mParticle: PurchaseTracking {
 
 extension mParticle: UserAttributeTracking {
     
-    /**
-     Sets the User Attribute through mParticle.
-     
-     - parameter key:   The key of the user attribute
-     - parameter value: the value of the user attribute
-     */
+    /// Sets the User Attribute.
+    ///
+    /// - Parameters:
+    ///   - key: The attribute key to log.
+    ///   - value: The attribute value to log.
+    /// - Returns: A tracking result.
     public func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         MParticle.sharedInstance().setUserAttribute(key, value: value)
 
@@ -300,10 +293,10 @@ extension mParticle: ViewDetailLogging {
 
     /// Logs the action of viewing a product's details.
     ///
-    /// - parameter product: The SimcoeProductConvertible instance.
-    /// - parameter eventProperties: The event properties.
-    ///
-    /// - returns: A tracking result.
+    /// - Parameters:
+    ///   - product: The SimcoeProductConvertible instance.
+    ///   - eventProperties: The event properties.
+    /// - Returns: A tracking result.
     public func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .viewDetail,

--- a/Simcoe/mParticle/mParticle.swift
+++ b/Simcoe/mParticle/mParticle.swift
@@ -154,7 +154,7 @@ extension mParticle: EventTracking {
             return .error(message: "Cannot track an event without valid properties.")
         }
 
-        properties[MPEventKeys.name.rawValue] = event as AnyObject
+        properties[MPEventKeys.name.rawValue] = event as String
 
         let event: MPEvent
         do {
@@ -213,9 +213,9 @@ extension mParticle: LocationTracking {
      - parameter properties: The properties for the MPEvent.
      */
     public func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
-        var eventProperties = properties ?? [String: AnyObject]() // TODO: Handle Error
-        eventProperties["latitude"] = location.coordinate.latitude as AnyObject
-        eventProperties["longitude"] = location.coordinate.longitude as AnyObject
+        var eventProperties = properties ?? Properties() // TODO: Handle Error
+        eventProperties["latitude"] = String(location.coordinate.latitude)
+        eventProperties["longitude"] = String(location.coordinate.longitude)
 
         let event: MPEvent
         do {
@@ -286,7 +286,7 @@ extension mParticle: UserAttributeTracking {
      - parameter key:   The key of the user attribute
      - parameter value: the value of the user attribute
      */
-    public func setUserAttribute(_ key: String, value: AnyObject) -> TrackingResult {
+    public func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         MParticle.sharedInstance().setUserAttribute(key, value: value)
 
         return .success

--- a/Simcoe/mParticle/mParticle.swift
+++ b/Simcoe/mParticle/mParticle.swift
@@ -9,16 +9,7 @@
 import mParticle_Apple_SDK
 
 /// Simcoe Analytics handler for the MParticle iOS SDK.
-open class mParticle: CartLogging,
-                      CheckoutTracking,
-                      ErrorLogging,
-                      EventTracking,
-                      LifetimeValueIncreasing,
-                      LocationTracking,
-                      PageViewTracking,
-                      PurchaseTracking,
-                      UserAttributeTracking,
-                      ViewDetailLogging {
+public class mParticle {
 
     fileprivate static let unknownErrorMessage = "An unknown error occurred."
 
@@ -51,7 +42,11 @@ open class mParticle: CartLogging,
         MParticle.sharedInstance().start()
     }
 
-    // MARK: - CartLogging
+}
+
+// MARK: - CartLogging
+
+extension mParticle: CartLogging {
 
     /// Logs the addition of a product to the cart.
     ///
@@ -59,7 +54,7 @@ open class mParticle: CartLogging,
     ///   - product: The SimcoeProductConvertible instance.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    open func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
+    public func logAddToCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .addToCart,
                                     products: [mPProduct],
@@ -76,7 +71,7 @@ open class mParticle: CartLogging,
     ///   - product: The SimcoeProductConvertible instance.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    open func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
+    public func logRemoveFromCart<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .removeFromCart,
                                     products: [mPProduct],
@@ -87,7 +82,11 @@ open class mParticle: CartLogging,
         return .success
     }
 
-    // MARK: - CheckoutTracking
+}
+
+// MARK: - CheckoutTracking
+
+extension mParticle: CheckoutTracking {
 
     /// Tracks a checkout event.
     ///
@@ -95,7 +94,7 @@ open class mParticle: CartLogging,
     ///   - products: The products.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    open func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
+    public func trackCheckoutEvent<T: SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         let mPProducts = products.map { MPProduct(product: $0) }
         let event = MPCommerceEvent(eventType: .checkout,
                                     products: mPProducts,
@@ -106,7 +105,11 @@ open class mParticle: CartLogging,
         return .success
     }
 
-    // MARK: - ErrorLogging
+}
+
+// MARK: - ErrorLogging
+
+extension mParticle: ErrorLogging {
 
     /// Logs an error through mParticle.
     ///
@@ -117,13 +120,17 @@ open class mParticle: CartLogging,
     ///   - error: The error to log.
     ///   - properties: The properties of the event.
     /// - Returns: A tracking result.
-    open func log(error: String, withAdditionalProperties properties: Properties? = nil) -> TrackingResult {
+    public func log(error: String, withAdditionalProperties properties: Properties? = nil) -> TrackingResult {
         MParticle.sharedInstance().logError(error, eventInfo: properties)
 
         return .success
     }
 
-    // MARK: - EventTracking
+}
+
+// MARK: - EventTracking
+
+extension mParticle: EventTracking {
 
     /// Tracks an mParticle event.
     ///
@@ -139,7 +146,7 @@ open class mParticle: CartLogging,
     ///   - event: The event name to log.
     ///   - properties: The properties of the event.
     /// - Returns: A tracking result.
-    open func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(event: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         guard var properties = properties else {
             return .error(message: "Cannot track an event without valid properties.")
         }
@@ -160,7 +167,11 @@ open class mParticle: CartLogging,
         return .success
     }
 
-    // MARK: - LifetimeValueIncreasing
+}
+
+// MARK: - LifetimeValueIncreasing
+
+extension mParticle: LifetimeValueIncreasing {
 
     /// Increases the lifetime value of the key by the specified amount.
     ///
@@ -169,14 +180,18 @@ open class mParticle: CartLogging,
     ///   - item: The optional item to extend.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    open func increaseLifetimeValue(byAmount amount: Double, forItem item: String?,
-                                      withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func increaseLifetimeValue(byAmount amount: Double, forItem item: String?,
+                                    withAdditionalProperties properties: Properties?) -> TrackingResult {
         MParticle.sharedInstance().logLTVIncrease(amount, eventName: (item ?? ""), eventInfo: properties)
 
         return .success
     }
 
-    // MARK: - LocationTracking
+}
+
+// MARK: - LocationTracking
+
+extension mParticle: LocationTracking {
 
     /// Tracks the user's location.
     ///
@@ -191,7 +206,7 @@ open class mParticle: CartLogging,
     ///   - location: The location data being tracked.
     ///   - properties: The properties for the MPEvent.
     /// - Returns: A tracking result.
-    open func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(location: CLLocation, withAdditionalProperties properties: Properties?) -> TrackingResult {
         var eventProperties = properties ?? Properties() // TODO: Handle Error
         eventProperties["latitude"] = String(location.coordinate.latitude)
         eventProperties["longitude"] = String(location.coordinate.longitude)
@@ -210,7 +225,11 @@ open class mParticle: CartLogging,
         return .success
     }
 
-    // MARK: - PageViewTracking
+}
+
+// MARK: - PageViewTracking
+
+extension mParticle: PageViewTracking {
 
     /// Tracks the page view.
     ///
@@ -218,13 +237,17 @@ open class mParticle: CartLogging,
     ///   - pageView: The page view to track.
     ///   - properties: The optional additional properties.
     /// - Returns: A tracking result.
-    open func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
+    public func track(pageView: String, withAdditionalProperties properties: Properties?) -> TrackingResult {
         MParticle.sharedInstance().logScreen(pageView, eventInfo: properties)
 
         return .success
     }
 
-    // MARK: - PurchaseTracking
+}
+
+// MARK: - PurchaseTracking
+
+extension mParticle: PurchaseTracking {
 
     /// Tracks a purchase event.
     ///
@@ -232,7 +255,7 @@ open class mParticle: CartLogging,
     ///   - products: The products.
     ///   - eventProperties: The event properties
     /// - Returns: A tracking result.
-    open func trackPurchaseEvent<T : SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
+    public func trackPurchaseEvent<T : SimcoeProductConvertible>(_ products: [T], eventProperties: Properties?) -> TrackingResult {
         let mPProducts = products.map { MPProduct(product: $0) }
         let event = MPCommerceEvent(eventType: .purchase,
                                     products: mPProducts,
@@ -243,7 +266,11 @@ open class mParticle: CartLogging,
         return .success
     }
 
-    // MARK: - UserAttributeTracking
+}
+
+// MARK: - UserAttributeTracking
+
+extension mParticle: UserAttributeTracking {
 
     /// Sets the User Attribute.
     ///
@@ -251,13 +278,17 @@ open class mParticle: CartLogging,
     ///   - key: The attribute key to log.
     ///   - value: The attribute value to log.
     /// - Returns: A tracking result.
-    open func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
+    public func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         MParticle.sharedInstance().setUserAttribute(key, value: value)
 
         return .success
     }
 
-    // MARK: - ViewDetailLogging
+}
+
+// MARK: - ViewDetailLogging
+
+extension mParticle: ViewDetailLogging {
 
     /// Logs the action of viewing a product's details.
     ///
@@ -265,7 +296,7 @@ open class mParticle: CartLogging,
     ///   - product: The SimcoeProductConvertible instance.
     ///   - eventProperties: The event properties.
     /// - Returns: A tracking result.
-    open func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
+    public func logViewDetail<T: SimcoeProductConvertible>(_ product: T, eventProperties: Properties?) -> TrackingResult {
         let mPProduct = MPProduct(product: product)
         let event = MPCommerceEvent(eventType: .viewDetail,
                                     products: [mPProduct],

--- a/SimcoeTests/Mocks/EventPropertiesFake.swift
+++ b/SimcoeTests/Mocks/EventPropertiesFake.swift
@@ -10,8 +10,8 @@
 
 internal final class EventPropertiesFake {
 
-    static let eventProperties: Properties = ["checkoutStep": 1 as Int,
-                                              "currency": "USD" as String,
-                                              "screenName": "home" as String]
+    static let eventProperties: Properties = ["checkoutStep": 1,
+                                              "currency": "USD",
+                                              "screenName": "home"]
     
 }

--- a/SimcoeTests/Mocks/EventPropertiesFake.swift
+++ b/SimcoeTests/Mocks/EventPropertiesFake.swift
@@ -10,7 +10,7 @@
 
 internal final class EventPropertiesFake {
 
-    static let eventProperties: Properties = ["checkoutStep": 1 as String,
+    static let eventProperties: Properties = ["checkoutStep": 1 as Int,
                                               "currency": "USD" as String,
                                               "screenName": "home" as String]
     

--- a/SimcoeTests/Mocks/EventPropertiesFake.swift
+++ b/SimcoeTests/Mocks/EventPropertiesFake.swift
@@ -10,8 +10,8 @@
 
 internal final class EventPropertiesFake {
 
-    static let eventProperties: Properties = ["checkoutStep": 1 as AnyObject,
-                                              "currency": "USD" as AnyObject,
-                                              "screenName": "home" as AnyObject]
+    static let eventProperties: Properties = ["checkoutStep": 1 as String,
+                                              "currency": "USD" as String,
+                                              "screenName": "home" as String]
     
 }

--- a/SimcoeTests/Mocks/ProductFake.swift
+++ b/SimcoeTests/Mocks/ProductFake.swift
@@ -18,8 +18,8 @@ internal struct ProductFake {
 
     let totalPrice: Double = 935.47
 
-    let properties: Properties = [ "sku": 348956743 as AnyObject,
-                                   "brand": "super" as AnyObject]
+    let properties: Properties = [ "sku": 348956743 as Int,
+                                   "brand": "super" as String]
 
 }
 

--- a/SimcoeTests/Mocks/UserAttributesFake.swift
+++ b/SimcoeTests/Mocks/UserAttributesFake.swift
@@ -14,7 +14,7 @@ internal final class UserAttributesFake: UserAttributeTracking {
     
     var attributesCallCount = 0
     
-    func setUserAttribute(_ key: String, value: AnyObject) -> TrackingResult {
+    func setUserAttribute(_ key: String, value: Any) -> TrackingResult {
         attributesCallCount += 1
         return .success
     }

--- a/SimcoeTests/SimcoeLoggingTests.swift
+++ b/SimcoeTests/SimcoeLoggingTests.swift
@@ -139,7 +139,7 @@ internal final class SimcoeLoggingTests: XCTestCase {
         simcoe.providers = [attributesSetter]
         let expectation = 1
 
-        simcoe.setUserAttribute("foo", value: "bar" as AnyObject)
+        simcoe.setUserAttribute("foo", value: "bar" as String)
 
         XCTAssertEqual(attributesSetter.attributesCallCount, expectation,
                        "Expected result = Called \(expectation) times; got \(attributesSetter.attributesCallCount)")

--- a/SimcoeTests/mParticle/MPEventTests.swift
+++ b/SimcoeTests/mParticle/MPEventTests.swift
@@ -13,9 +13,10 @@ import mParticle_Apple_SDK
 class MPEventTests: XCTestCase {
 
     func test_that_MPEvent_created_with_name_and_type() {
-        let properties: [String: AnyObject] =
-            [MPEventKeys.name.rawValue: "Event" as AnyObject,
-             MPEventKeys.eventType.rawValue: MPEventType.other.rawValue as AnyObject]
+        var properties = Properties()
+        properties[MPEventKeys.name.rawValue] = "Event" as String
+        properties[MPEventKeys.eventType.rawValue] = MPEventType.other.rawValue as UInt
+
         let event: MPEvent?
         let eventError: Error?
 
@@ -34,7 +35,9 @@ class MPEventTests: XCTestCase {
     }
 
     func test_that_name_error_thrown_when_missing() {
-        let properties: [String: AnyObject] = [MPEventKeys.eventType.rawValue: MPEventType.other.rawValue as AnyObject]
+        var properties = Properties()
+        properties[MPEventKeys.eventType.rawValue] = MPEventType.other.rawValue as UInt
+
         let expected = MPEventGenerationError.nameMissing
         let event: MPEvent?
         let eventError: Error?
@@ -54,7 +57,9 @@ class MPEventTests: XCTestCase {
     }
 
     func test_that_type_error_thrown_when_missing() {
-        let properties: [String: AnyObject] = [MPEventKeys.name.rawValue: "Test" as AnyObject]
+        var properties = Properties()
+        properties[MPEventKeys.name.rawValue] = "Test" as String
+
         let expected = MPEventGenerationError.typeMissing
         let event: MPEvent?
         let eventError: Error?
@@ -172,7 +177,7 @@ class MPEventTests: XCTestCase {
         let key = "Stuff"
         let value = 42
 
-        let data = MPEvent.eventData(type: .other, name: name, info: [key: value as AnyObject])
+        let data = MPEvent.eventData(type: .other, name: name, info: [key: value as Int])
         let result = try! MPEvent.toEvent(usingData: data)
 
         XCTAssertNotNil(result.info,

--- a/SimcoeTests/mParticle/MPEventTests.swift
+++ b/SimcoeTests/mParticle/MPEventTests.swift
@@ -14,8 +14,8 @@ class MPEventTests: XCTestCase {
 
     func test_that_MPEvent_created_with_name_and_type() {
         var properties = Properties()
-        properties[MPEventKeys.name.rawValue] = "Event" as String
-        properties[MPEventKeys.eventType.rawValue] = MPEventType.other.rawValue as UInt
+        properties[MPEventKeys.name.rawValue] = "Event"
+        properties[MPEventKeys.eventType.rawValue] = MPEventType.other.rawValue
 
         let event: MPEvent?
         let eventError: Error?
@@ -36,7 +36,7 @@ class MPEventTests: XCTestCase {
 
     func test_that_name_error_thrown_when_missing() {
         var properties = Properties()
-        properties[MPEventKeys.eventType.rawValue] = MPEventType.other.rawValue as UInt
+        properties[MPEventKeys.eventType.rawValue] = MPEventType.other.rawValue
 
         let expected = MPEventGenerationError.nameMissing
         let event: MPEvent?
@@ -58,7 +58,7 @@ class MPEventTests: XCTestCase {
 
     func test_that_type_error_thrown_when_missing() {
         var properties = Properties()
-        properties[MPEventKeys.name.rawValue] = "Test" as String
+        properties[MPEventKeys.name.rawValue] = "Test"
 
         let expected = MPEventGenerationError.typeMissing
         let event: MPEvent?


### PR DESCRIPTION
This PR:

- makes some minor adjustments to the dictionary type casting
- updates documentation to Xcode 8 standards
- shifts the protocol implementations of Adobe.swift and mParticle.swift into the main class

Addresses issues: Issue #25 Issue #26 