### PR TITLE
[Chore] Refactored tracker's track(event:) method

### DIFF
--- a/Simcoe/Tracker.swift
+++ b/Simcoe/Tracker.swift
@@ -15,9 +15,6 @@ public final class Tracker {
     /// The error option for the recorder. Defaults to .Default.
     public var errorOption: ErrorHandlingOption = .default
 
-    /// The list of events to track.
-    var events = [Event]()
-
     fileprivate let outputSources: [Output]
 
     /// Initializes a new instance using the specified source as its output. By default, this is the
@@ -32,11 +29,6 @@ public final class Tracker {
     ///
     /// - Parameter event: The event to record.
     func track(event: Event) {
-        events.append(event)
-        parseEvent(event)
-    }
-
-    fileprivate func parseEvent(_ event: Event) {
         let successfulProviders = event.writeEvents.map { writeEvent -> AnalyticsTracking? in
             switch writeEvent.trackingResult {
             case .success:

--- a/SimcoeTests/TrackerTests.swift
+++ b/SimcoeTests/TrackerTests.swift
@@ -26,8 +26,8 @@ class TrackerTests: XCTestCase {
 
         simcoe.track(pageView: "test", withAdditionalProperties: nil, providers: nil)
 
-        XCTAssertEqual(expectation, simcoe.tracker.events.count,
-                       "Expected result = \(expectation); got \(simcoe.tracker.events.count)")
+        XCTAssertEqual(expectation, outputSource.printCallCount,
+                       "Expected result = \(expectation); got \(outputSource.printCallCount)")
     }
 
     func test_recording_to_input_providers() {
@@ -50,8 +50,8 @@ class TrackerTests: XCTestCase {
 
         simcoe.track(pageView: "1234")
 
-        XCTAssertEqual(expectation, simcoe.tracker.events.count,
-            "Expected result = \(expectation); got \(simcoe.tracker.events.count)")
+        XCTAssertEqual(expectation, outputSource.printCallCount,
+            "Expected result = \(expectation); got \(outputSource.printCallCount)")
     }
 
     func test_that_it_does_not_write_when_option_none() {


### PR DESCRIPTION
Removed the unused `events` array property in the `Tracker` class