### PR TITLE
Chore/update mparticle version braze fix

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,24 +5,24 @@ PODS:
   - Mixpanel-swift (2.4.4):
     - Mixpanel-swift/Complete (= 2.4.4)
   - Mixpanel-swift/Complete (2.4.4)
-  - mParticle-Apple-SDK (7.5.1):
-    - mParticle-Apple-SDK/mParticle (= 7.5.1)
-  - mParticle-Apple-SDK/mParticle (7.5.1)
-  - Simcoe/Adobe (1.2.0):
+  - mParticle-Apple-SDK (7.5.4):
+    - mParticle-Apple-SDK/mParticle (= 7.5.4)
+  - mParticle-Apple-SDK/mParticle (7.5.4)
+  - Simcoe/Adobe (2.0.0):
     - AdobeMobileSDK (~> 4.13)
     - Simcoe/Core
-  - Simcoe/Core (1.2.0)
-  - Simcoe/Mixpanel (1.2.0):
+  - Simcoe/Core (2.0.0)
+  - Simcoe/Mixpanel (2.0.0):
     - Mixpanel-swift (~> 2.4.4)
     - Simcoe/Core
-  - Simcoe/mParticle (1.2.0):
-    - mParticle-Apple-SDK (= 7.5.1)
+  - Simcoe/mParticle (2.0.0):
+    - mParticle-Apple-SDK (= 7.5.4)
     - Simcoe/Core
 
 DEPENDENCIES:
   - AdobeMobileSDK (~> 4.13)
   - Mixpanel-swift (~> 2.4.4)
-  - mParticle-Apple-SDK (= 7.5.1)
+  - mParticle-Apple-SDK (= 7.5.4)
   - Simcoe/Adobe (from `./`)
   - Simcoe/Mixpanel (from `./`)
   - Simcoe/mParticle (from `./`)
@@ -34,8 +34,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AdobeMobileSDK: de79920972a9abcf4e27b141fb79d0262fe9ee11
   Mixpanel-swift: 1908db7a972b362fcab1a0c3b37ec6087b95d8d9
-  mParticle-Apple-SDK: e901dec4147c3f1c041c2cb493b129ae652e26f1
-  Simcoe: 014cb7317cc7f51472dfd3202db86fd960288696
+  mParticle-Apple-SDK: 9ab63c0a4e6c87df727866455f8b633fdef54873
+  Simcoe: 0156f91dfdd147ffdc0786d675209228e78489f2
 
 PODFILE CHECKSUM: 8d8a42d64db1433bbfb67a53162f9258ec0d74fb
 

--- a/Simcoe.podspec
+++ b/Simcoe.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   # Each subspec represents an analytics library implemented using Simcoe.
 
   adobe		  =   { :name => "Adobe",           :dependency => "AdobeMobileSDK", :version => '~> 4.13' }
-  mParticle =   { :name => "mParticle",       :dependency => "mParticle-Apple-SDK", :version => '7.5.1' }
+  mParticle =   { :name => "mParticle",       :dependency => "mParticle-Apple-SDK", :version => '7.5.4' }
   mixpanel  =   { :name => "Mixpanel",        :dependency => "Mixpanel-swift", :version => '~> 2.4.4' }
 
   all_specs = [adobe, mParticle, mixpanel]

--- a/Simcoe.podspec
+++ b/Simcoe.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Simcoe"
-  s.version      = "1.2.0"
+  s.version      = "2.0.0"
   s.summary      = "An analytics framework that provides a base layer of simple APIs for managing analytics frameworks."
   s.description  = <<-DESC
                     Simcoe is an analytics framework that aims to provide a simple, extensible API for managing and handling various analytics frameworks. It makes very few assumptions about your analytics implementations, allowing the implementer to customize it to their needs.


### PR DESCRIPTION
Updates the pinned mParticle version to the latest release for a fix related to how user identities are tracked across mParticle + Braze

```
We have uncovered some changes that need to be made to the way we handle identities for Braze.
```