### PR TITLE
Release 2.0.1

### DIFF
--- a/Simcoe.podspec
+++ b/Simcoe.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Simcoe"
-  s.version      = "2.0.0"
+  s.version      = "2.0.1"
   s.summary      = "An analytics framework that provides a base layer of simple APIs for managing analytics frameworks."
   s.description  = <<-DESC
                     Simcoe is an analytics framework that aims to provide a simple, extensible API for managing and handling various analytics frameworks. It makes very few assumptions about your analytics implementations, allowing the implementer to customize it to their needs.


### PR DESCRIPTION
After syncing with @hkellaway -- wanted to get into the habit of setting up the release off _master_

Releases version 2.0.1 which will contain the mParticle version bump hotfix