### PR TITLE
[Feature] Bump mParticle version to 7.5.6

### DIFF
--- a/Simcoe.podspec
+++ b/Simcoe.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   # Each subspec represents an analytics library implemented using Simcoe.
 
   adobe		  =   { :name => "Adobe",           :dependency => "AdobeMobileSDK", :version => '~> 4.13' }
-  mParticle =   { :name => "mParticle",       :dependency => "mParticle-Apple-SDK", :version => '7.5.4' }
+  mParticle =   { :name => "mParticle",       :dependency => "mParticle-Apple-SDK", :version => '7.5.6' }
   mixpanel  =   { :name => "Mixpanel",        :dependency => "Mixpanel-swift", :version => '~> 2.4.4' }
 
   all_specs = [adobe, mParticle, mixpanel]


### PR DESCRIPTION
Bump the mParticle version number from 7.5.4 to 7.5.6

`a bug...with the mParticle version 7 kit, which I understand the mParticle team will be pushing live today or tomorrow. This causes some custom events to be labeled as "Other" (see screenshot). `